### PR TITLE
Add retry wrapper function

### DIFF
--- a/src/main/kotlin/no/nav/dagpenger/http/Retry.kt
+++ b/src/main/kotlin/no/nav/dagpenger/http/Retry.kt
@@ -36,4 +36,4 @@ fun <T : Any> retryFuelHttp(
     return function()
 }
 
-private fun Logger.warn(exception: Throwable) = error(exception.message ?: "Exception of type ${exception.javaClass}", exception)
+private fun Logger.warn(exception: Throwable) = warn(exception.message ?: "Exception of type ${exception.javaClass}", exception)

--- a/src/main/kotlin/no/nav/dagpenger/http/Retry.kt
+++ b/src/main/kotlin/no/nav/dagpenger/http/Retry.kt
@@ -1,0 +1,39 @@
+package no.nav.dagpenger.http
+
+import com.github.kittinunf.fuel.core.FuelError
+import com.github.kittinunf.fuel.core.Request
+import com.github.kittinunf.fuel.core.Response
+import com.github.kittinunf.result.Result
+import mu.KotlinLogging
+import org.slf4j.Logger
+
+private val LOGGER = KotlinLogging.logger {}
+
+fun <T : Any> retryFuelHttp(
+    times: Int = 5,
+    initialDelay: Long = 500,
+    maxDelay: Long = 5000,
+    factor: Double = 2.0,
+    allowedErrorCodes: List<Int> = emptyList(),
+    function: () -> Triple<Request, Response, Result<T, FuelError>>
+): Triple<Request, Response, Result<T, FuelError>>
+{
+    var currentDelay = initialDelay
+    repeat(times - 1) {
+
+        val res = function()
+        val (_, response, result) = res
+        when {
+            result is Result.Success -> return res
+            result is Result.Failure && response.statusCode in allowedErrorCodes -> return res
+            result is Result.Failure -> LOGGER.warn(result.getException())
+        }
+
+        LOGGER.info("Retrying in $currentDelay ms")
+        Thread.sleep(currentDelay)
+        currentDelay = (currentDelay * factor).toLong().coerceAtMost(maxDelay)
+    }
+    return function()
+}
+
+private fun Logger.warn(exception: Throwable) = error(exception.message ?: "Exception of type ${exception.javaClass}", exception)


### PR DESCRIPTION
A possible way to solve the need for http retry. Added it to streams, in lack of a better place to put it

Is used like this:
```
val (_, response, result) = retryFuelHttp {
    with(url.httpPost().body(fødselsNummer)) {
        responseObject<GeografiskTilknytningResponse>()
    }
}
```
or
```
val (_, response, result) = retryFuelHttp(allowedErrorCodes = listOf(410, 418)) {
    with(url.httpPost().body(fødselsNummer)) {
        responseObject<GeografiskTilknytningResponse>()
    }
}
```

