### PR TITLE
Handle failures onPacket

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,7 @@ tasks.withType<KotlinCompile> {
 }
 
 group = "no.nav.dagpenger"
-version = "0.3.4-SNAPSHOT"
+version = "0.3.5-SNAPSHOT"
 
 val kafkaVersion = "2.0.1"
 val confluentVersion = "5.0.2"

--- a/src/main/kotlin/no/nav/dagpenger/streams/River.kt
+++ b/src/main/kotlin/no/nav/dagpenger/streams/River.kt
@@ -2,6 +2,7 @@ package no.nav.dagpenger.streams
 
 import mu.KotlinLogging
 import no.nav.dagpenger.events.Packet
+import no.nav.dagpenger.events.Problem
 import no.nav.dagpenger.streams.Topics.DAGPENGER_BEHOV_PACKET_EVENT
 import org.apache.kafka.streams.StreamsBuilder
 import org.apache.kafka.streams.Topology
@@ -14,10 +15,23 @@ abstract class River : Service() {
     override fun buildTopology(): Topology {
         val builder = StreamsBuilder()
         val stream = builder.consumeTopic(DAGPENGER_BEHOV_PACKET_EVENT)
-        stream.peek { key, packet -> LOGGER.info("Processing $packet with key $key") }
+        stream
+            .filterNot { _, packet ->
+                if (packet.hasProblem()) {
+                    LOGGER.warn { "Skipping packet with problem. Packet $packet" }
+                }
+                packet.hasProblem()
+            }
             .filter { key, packet -> filterPredicates().all { it.test(key, packet) } }
             .mapValues { _, packet ->
-                onPacket(packet)
+                val result = runCatching { onPacket(packet) }
+                return@mapValues when {
+                    result.isFailure -> {
+                        LOGGER.error(result.exceptionOrNull()) { "Failed to process packet" }
+                        return@mapValues onFailure(packet)
+                    }
+                    else -> result.getOrThrow()
+                }
             }
             .peek { key, packet -> LOGGER.info("Producing $packet with key $key") }
             .toTopic(DAGPENGER_BEHOV_PACKET_EVENT)
@@ -26,4 +40,12 @@ abstract class River : Service() {
 
     abstract fun filterPredicates(): List<Predicate<String, Packet>>
     abstract fun onPacket(packet: Packet): Packet
+    open fun onFailure(packet: Packet): Packet {
+        packet.addProblem(
+            Problem(
+                title = "Ukjent feil ved behandling av Packet"
+            )
+        )
+        return packet
+    }
 }

--- a/src/main/kotlin/no/nav/dagpenger/streams/StreamConfig.kt
+++ b/src/main/kotlin/no/nav/dagpenger/streams/StreamConfig.kt
@@ -6,6 +6,7 @@ import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.common.config.SaslConfigs
 import org.apache.kafka.common.config.SslConfigs
 import org.apache.kafka.streams.StreamsConfig
+import org.apache.kafka.streams.StreamsConfig.EXACTLY_ONCE
 import org.apache.kafka.streams.errors.LogAndFailExceptionHandler
 import java.io.File
 import java.lang.System.getenv
@@ -27,7 +28,7 @@ fun streamConfig(
                         StreamsConfig.BOOTSTRAP_SERVERS_CONFIG to bootStapServerUrl,
                         StreamsConfig.APPLICATION_ID_CONFIG to appId,
                         // TODO Using processing guarantee requires replication of 3, not possible with current single node dev environment
-                        //StreamsConfig.PROCESSING_GUARANTEE_CONFIG to "exactly_once",
+                        StreamsConfig.PROCESSING_GUARANTEE_CONFIG to EXACTLY_ONCE,
                         StreamsConfig.COMMIT_INTERVAL_MS_CONFIG to 1,
                         ConsumerConfig.AUTO_OFFSET_RESET_CONFIG to "earliest",
                         StreamsConfig.DEFAULT_DESERIALIZATION_EXCEPTION_HANDLER_CLASS_CONFIG to LogAndFailExceptionHandler::class.java

--- a/src/test/kotlin/no/nav/dagpenger/streams/RiverTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/streams/RiverTest.kt
@@ -1,6 +1,7 @@
 package no.nav.dagpenger.streams
 
 import no.nav.dagpenger.events.Packet
+import no.nav.dagpenger.events.Problem
 import org.apache.kafka.streams.StreamsConfig
 import org.apache.kafka.streams.TopologyTestDriver
 import org.apache.kafka.streams.kstream.Predicate
@@ -57,6 +58,80 @@ class RiverTest {
             assertEquals(1, ut.value().getNullableIntValue("key1"))
             assertEquals("value1", ut.value().getNullableStringValue("key2"))
             assertEquals(true, ut.value().getBoolean("key3"))
+        }
+    }
+
+    class FailingTestService : River() {
+        override val SERVICE_APP_ID = "TestService"
+
+        override fun filterPredicates(): List<Predicate<String, Packet>> {
+            return listOf(Predicate { _, packet -> !packet.hasField("new") })
+        }
+
+        override fun onPacket(packet: Packet): Packet {
+            throw RuntimeException("Fail to process")
+        }
+    }
+
+    class FailingTestServiceOnFailure : River() {
+        override val SERVICE_APP_ID = "TestService"
+
+        override fun filterPredicates(): List<Predicate<String, Packet>> {
+            return listOf(Predicate { _, packet -> !packet.hasField("new") })
+        }
+
+        override fun onPacket(packet: Packet): Packet {
+            throw RuntimeException("Fail to process")
+            //   packet.putValue("new", "newvalue")
+            // return packet
+        }
+
+        override fun onFailure(packet: Packet): Packet {
+            packet.addProblem(
+                Problem(
+                    title = "ERROR"
+
+                )
+            )
+            return packet
+        }
+    }
+
+    @Test
+    fun ` River should add problem if service fails to process onPacket `() {
+        val testService = FailingTestService()
+
+        TopologyTestDriver(testService.buildTopology(), config).use { topologyTestDriver ->
+            val inputRecord = factory.create(Packet(jsonString))
+            topologyTestDriver.pipeInput(inputRecord)
+            val ut = topologyTestDriver.readOutput(
+                Topics.DAGPENGER_BEHOV_PACKET_EVENT.name,
+                Topics.DAGPENGER_BEHOV_PACKET_EVENT.keySerde.deserializer(),
+                Topics.DAGPENGER_BEHOV_PACKET_EVENT.valueSerde.deserializer()
+            )
+
+            assertTrue { ut != null }
+            assertTrue { ut.value().hasProblem() }
+            assertEquals("Ukjent feil ved behandling av Packet", ut.value().getProblem()?.title)
+        }
+    }
+
+    @Test
+    fun ` River should add problem if service fails to process onPacket with specified onFailure proble`() {
+        val testService = FailingTestServiceOnFailure()
+
+        TopologyTestDriver(testService.buildTopology(), config).use { topologyTestDriver ->
+            val inputRecord = factory.create(Packet(jsonString))
+            topologyTestDriver.pipeInput(inputRecord)
+            val ut = topologyTestDriver.readOutput(
+                Topics.DAGPENGER_BEHOV_PACKET_EVENT.name,
+                Topics.DAGPENGER_BEHOV_PACKET_EVENT.keySerde.deserializer(),
+                Topics.DAGPENGER_BEHOV_PACKET_EVENT.valueSerde.deserializer()
+            )
+
+            assertTrue { ut != null }
+            assertTrue { ut.value().hasProblem() }
+            assertEquals("ERROR", ut.value().getProblem()?.title)
         }
     }
 

--- a/src/test/kotlin/no/nav/dagpenger/streams/RiverTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/streams/RiverTest.kt
@@ -82,8 +82,6 @@ class RiverTest {
 
         override fun onPacket(packet: Packet): Packet {
             throw RuntimeException("Fail to process")
-            //   packet.putValue("new", "newvalue")
-            // return packet
         }
 
         override fun onFailure(packet: Packet): Packet {


### PR DESCRIPTION
- Services can override error handling (problem) by implementing onFailure method.